### PR TITLE
Change Update method to return ExtraTypeHandle - Compatibility fix for 1.4.2f1

### DIFF
--- a/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/ExtraTypeHandle.cs
+++ b/TrafficLightsEnhancement/Systems/TrafficLightSystems/Initialisation/ExtraTypeHandle.cs
@@ -57,7 +57,7 @@ public struct ExtraTypeHandle
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Update(ref SystemState state)
+    public ExtraTypeHandle Update(ref SystemState state)
     {
         m_Entity.Update(ref state);
         m_ConnectedEdge.Update(ref state);
@@ -73,5 +73,6 @@ public struct ExtraTypeHandle
         m_EdgeGroupMask.Update(ref state);
         m_SubLaneGroupMask.Update(ref state);
         m_CustomPhaseData.Update(ref state);
+        return this;
     }
 }


### PR DESCRIPTION
Fixes for 1.4.2f1

I don't think the author accepts pull requests but if somebody wants to compile go ahead.

I also have no idea what I am doing, I just really needed this mod to work because the game is unplayable without it.

Edit: Incompatible with extra detailing tools, icon disappears.